### PR TITLE
Windows compile

### DIFF
--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -227,7 +227,7 @@ jobs:
         working-directory: puredata
         run: |
           mkdir build
-          conan install . -pr=./mingw-profile.txt --output-folder=build --build=missing
+          conan install . -pr:h=./mingw-profile.txt -pr:b=./mingw-profile.txt --output-folder=build --build=missing
 
       - name: Build External
         shell: bash

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -152,7 +152,6 @@ jobs:
           arch: x64
 
       - name: Install Pd
-        shell: pwsh
         run: |
           wget -q -O Pd.zip http://msp.ucsd.edu/Software/pd-0.53-2.msw.zip
           rm -rf "${PROGRAMFILES}/pd" && mkdir -p "${PROGRAMFILES}/pd"

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -191,9 +191,14 @@ jobs:
       - name: Set up Conan
         shell: bash
         run: |
+          set -euo pipefail
           pip install conan
 
-          PROFILE="$HOME/.conan2/profiles/mingw"
+
+          PROFILE_DIR="$HOME/.conan2/profiles"
+          mkdir -p "$PROFILE_DIR"
+
+          PROFILE="$PROFILE_DIR/mingw"
 
           cat > "$PROFILE" << 'EOF'
           [settings]
@@ -211,6 +216,7 @@ jobs:
           conan profile show mingw
 
       - name: Install Dependencies
+        shell: bash
         working-directory: puredata
         run: |
           mkdir -p build

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -137,6 +137,7 @@ jobs:
           submodules: true
 
       - name: Ensure core artifact id present
+        shell: bash
         env:
           CORE_RUN_ID: ${{ github.event.workflow_run.id || inputs.core_run_id }}
         run: |

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -188,39 +188,50 @@ jobs:
           run-id: ${{ github.event.workflow_run.id || inputs.core_run_id }}
           github-token: ${{ github.token }}
 
+      # - name: Set up Conan
+      #   shell: bash
+      #   run: |
+      #     pip install conan
+
+      #     conan profile detect --name mingw --force
+
+      #     PROFILE_PATH=$(conan profile path default)
+
+      #     echo "Default profile path: $PROFILE_PATH"
+
+      #     conan profile set settings.os=Windows mingw
+      #     conan profile set settings.arch=x86_64 mingw
+      #     conan profile set settings.compiler=gcc mingw
+      #     conan profile set settings.compiler.version=13 mingw
+      #     conan profile set settings.compiler.libcxx=libstdc++11 mingw
+      #     conan profile set settings.build_type=Release mingw
+
+      #     conan profile set conf.tools.build:compiler_executables.c=x86_64-w64-mingw32-gcc mingw
+      #     conan profile set conf.tools.build:compiler_executables.cpp=x86_64-w64-mingw32-g++ mingw
+
+      #     conan profile show mingw
+
+      # - name: Install Dependencies
+      #   shell: bash
+      #   working-directory: puredata
+      #   run: |
+      #     mkdir -p build
+      #     conan install . --output-folder=build --build=missing -pr:b=mingw -pr:h=mingw
+
       - name: Set up Conan
-        shell: bash
         run: |
-          set -euo pipefail
           pip install conan
-
-
-          PROFILE_DIR="$HOME/.conan2/profiles"
-          mkdir -p "$PROFILE_DIR"
-
-          PROFILE="$PROFILE_DIR/mingw"
-
-          cat > "$PROFILE" << 'EOF'
-          [settings]
-          os=Windows
-          arch=x86_64
-          build_type=Release
-          compiler=gcc
-          compiler.version=13
-          compiler.libcxx=libstdc++11
-
-          [conf]
-          tools.build:compiler_executables={"c":"x86_64-w64-mingw32-gcc","cpp":"x86_64-w64-mingw32-g++"}
-          EOF
-
-          conan profile show mingw
+          conan profile detect --force
 
       - name: Install Dependencies
-        shell: bash
-        working-directory: puredata
+        working-directory: core
         run: |
-          mkdir -p build
-          conan install . --output-folder=build --build=missing -pr:b=mingw -pr:h=mingw
+          mkdir build
+          conan install . --output-folder=build --build=missing `
+            -s compiler=gcc `
+            -s compiler.version=13 `
+            -s compiler.libcxx=libstdc++11 `
+            -s build_type=Release
 
       - name: Build External
         shell: bash

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -20,10 +20,6 @@ on:
     types:
       - completed
 
-defaults:
-  run:
-    shell: bash
-
 jobs:
   macOS:
     runs-on: macos-latest
@@ -155,7 +151,7 @@ jobs:
           arch: x64
 
       - name: Install Pd
-        id: pd
+        shell: pwsh
         run: |
           wget -q -O Pd.zip http://msp.ucsd.edu/Software/pd-0.53-2.msw.zip
           rm -rf "${PROGRAMFILES}/pd" && mkdir -p "${PROGRAMFILES}/pd"
@@ -172,9 +168,6 @@ jobs:
           path: core/lib/
           run-id: ${{ github.event.workflow_run.id || inputs.core_run_id }}
           github-token: ${{ github.token }}
-
-      # - name: Display structure of downloaded files
-      #   run: ls -la core/lib/
 
       - name: Set up Conan
         run: |
@@ -194,6 +187,7 @@ jobs:
           conan install . --output-folder=build --build=missing -pr:b=mingw -pr:h=mingw
 
       - name: Build External
+        shell: bash
         working-directory: puredata
         run: |
           mingw32-make

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -189,15 +189,26 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Set up Conan
+        shell: bash
         run: |
           pip install conan
-          conan profile detect --name=mingw --force
-          conan profile update settings.compiler=gcc mingw
-          conan profile update settings.compiler.version=13 mingw
-          conan profile update settings.compiler.libcxx=libstdc++11 mingw
-          conan profile update settings.os=Windows mingw
-          conan profile update settings.arch=x86_64 mingw
-          conan profile update settings.build_type=Release mingw
+
+          PROFILE="$HOME/.conan2/profiles/mingw"
+
+          cat > "$PROFILE" << 'EOF'
+          [settings]
+          os=Windows
+          arch=x86_64
+          build_type=Release
+          compiler=gcc
+          compiler.version=13
+          compiler.libcxx=libstdc++11
+
+          [conf]
+          tools.build:compiler_executables={"c":"x86_64-w64-mingw32-gcc","cpp":"x86_64-w64-mingw32-g++"}
+          EOF
+
+          conan profile show mingw
 
       - name: Install Dependencies
         working-directory: puredata

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -227,8 +227,7 @@ jobs:
         working-directory: puredata
         run: |
           mkdir build
-          conan install . -of=build --build=missing \
-            -pr:h=./mingw-profile.txt -pr:b=./mingw-profile.txt
+          conan install . -pr=./mingw-profile.txt --output-folder=build --build=missing
 
       - name: Build External
         shell: bash

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -224,14 +224,11 @@ jobs:
           conan profile detect --force
 
       - name: Install Dependencies
-        working-directory: core
+        working-directory: puredata
         run: |
           mkdir build
-          conan install . --output-folder=build --build=missing `
-            -s compiler=gcc `
-            -s compiler.version=13 `
-            -s compiler.libcxx=libstdc++11 `
-            -s build_type=Release
+          conan install . -of=build --build=missing \
+            -pr:h=./mingw-profile.txt -pr:b=./mingw-profile.txt
 
       - name: Build External
         shell: bash

--- a/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
+++ b/.github/workflows/build-puredata-plugins-with-pd-lib-builder.yml
@@ -152,14 +152,33 @@ jobs:
           arch: x64
 
       - name: Install Pd
+        id: pd
+        shell: pwsh
         run: |
-          wget -q -O Pd.zip http://msp.ucsd.edu/Software/pd-0.53-2.msw.zip
-          rm -rf "${PROGRAMFILES}/pd" && mkdir -p "${PROGRAMFILES}/pd"
-          unzip -q Pd.zip -d "${PROGRAMFILES}/pd"
-          mv -v "${PROGRAMFILES}/pd"/*/* "${PROGRAMFILES}/pd"
-          rm -f Pd.zip
-          export PD="${PROGRAMFILES}/pd/bin/pd.com"
-          echo "PD=${PD}" | tee "$GITHUB_OUTPUT"
+          $ErrorActionPreference = "Stop"
+
+          $url = "http://msp.ucsd.edu/Software/pd-0.53-2.msw.zip"
+          $zip = Join-Path $env:RUNNER_TEMP "Pd.zip"
+          $pdDir = Join-Path $env:ProgramFiles "pd"
+
+          Invoke-WebRequest $url -OutFile $zip
+
+          if (Test-Path $pdDir) { Remove-Item $pdDir -Recurse -Force }
+          New-Item -ItemType Directory -Path $pdDir | Out-Null
+
+          Expand-Archive -LiteralPath $zip -DestinationPath $pdDir -Force
+          Remove-Item $zip -Force
+
+          # flatten nested directory
+          $top = Get-ChildItem $pdDir | Where-Object { $_.PSIsContainer } | Select-Object -First 1
+          if ($top) {
+            Get-ChildItem $top.FullName | Move-Item -Destination $pdDir -Force
+            Remove-Item $top.FullName -Recurse -Force
+          }
+
+          $pd = "$pdDir\bin\pd.com"
+          "PD=$pd" | Out-File -FilePath $env:GITHUB_ENV -Append
+          "PD=$pd" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
       - name: Download zerr-core library
         uses: actions/download-artifact@v4

--- a/puredata/Makefile
+++ b/puredata/Makefile
@@ -6,6 +6,7 @@ CC  = g++
 cflags += -std=c++17 -Wall -DYAML_CPP_STATIC_DEFINE
 
 include build/conandeps.mk
+
 cflags += -I$(CONAN_INCLUDE_DIRS_YAML_CPP) -I$(CONAN_INCLUDE_DIRS_FFTW)
 # ldflags = -L$(CONAN_LIB_DIRS_YAML_CPP)  # Add library directories
 # ldlibs = -l$(CONAN_LIBS_YAML_CPP)       # Link the yaml-cpp library

--- a/puredata/mingw-profile.txt
+++ b/puredata/mingw-profile.txt
@@ -1,0 +1,13 @@
+[settings]
+os=Windows
+arch=x86_64
+build_type=Release
+compiler=gcc
+compiler.version=13
+compiler.libcxx=libstdc++11
+compiler.threads=posix
+compiler.exception=seh
+compiler.cppstd=17
+
+[conf]
+tools.build:compiler_executables={"c":"x86_64-w64-mingw32-gcc","cpp":"x86_64-w64-mingw32-g++"}


### PR DESCRIPTION
Change the GitHub action to use MinGW as the default instead of MSVC.
This is compatible with the PD-lib-builder.
This means that I can now compile the Windows version of PD externals.